### PR TITLE
provide real streaming scan method - to develop

### DIFF
--- a/src/Quahog/Client.php
+++ b/src/Quahog/Client.php
@@ -1,6 +1,7 @@
 <?php
 namespace Quahog;
 
+use InvalidArgumentException;
 use Quahog\Exception\ConnectionException;
 use Socket\Raw\Socket;
 
@@ -130,6 +131,35 @@ class Client
     public function contScan($file)
     {
         $this->_sendCommand('CONTSCAN ' . $file);
+
+        $response = $this->_receiveResponse();
+
+        return $this->_parseResponse($response);
+    }
+
+    /**
+     * Scan a stream
+     *
+     * @param resource $stream A file stream in string form
+     * @param int $maxChunkSize The maximum chunk size in bytes to send to clamd at a time
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    public function scanResourceStream($stream, $maxChunkSize = 1024)
+    {
+        if (!is_resource($stream)) {
+            throw new InvalidArgumentException('Passed stream is not a resource!');
+        }
+
+        $this->_sendCommand("INSTREAM");
+
+        while ($chunk = fread($stream, $maxChunkSize)) {
+            $size = pack('N', strlen($chunk));
+            $this->socket->send($size, MSG_DONTROUTE);
+            $this->socket->send($chunk, MSG_DONTROUTE);
+        }
+
+        $this->socket->send(pack('N', 0), MSG_DONTROUTE);
 
         $response = $this->_receiveResponse();
 


### PR DESCRIPTION
Hi there!

We needed to be able to stream big files into clamav, so I added a method handling a resource (like fopen('/some/file', 'r')). Works nice and scans whole file in one go. One thing to take into account is setting StreamMaxLength in clamd.conf to desired size, default is 25M. I had broken pipes when I tried to scan 140mb PDF file but everything went fine after I changed StreamMaxLength to 2000M.

Cheers!
ps. sorry for #7 