### PR TITLE
Changed "private" methods and properties to "protected"

### DIFF
--- a/src/Quahog/Client.php
+++ b/src/Quahog/Client.php
@@ -14,7 +14,7 @@ class Client
     /**
      * @var Socket
      */
-    private $socket;
+    protected $socket;
 
     /**
      * Instantiate a Quahog\Client instance
@@ -183,7 +183,7 @@ class Client
      *
      * @param string $command
      */
-    private function _sendCommand($command)
+    protected function _sendCommand($command)
     {
         $this->socket->send("n$command\n", MSG_DONTROUTE);
     }
@@ -193,7 +193,7 @@ class Client
      *
      * @return string
      */
-    private function _receiveResponse()
+    protected function _receiveResponse()
     {
         $result = $this->socket->read(4096);
 
@@ -208,7 +208,7 @@ class Client
      * @param string $response
      * @return array
      */
-    private function _parseResponse($response)
+    protected function _parseResponse($response)
     {
         $splitResponse = explode(': ', $response);
 


### PR DESCRIPTION
# What Was Changed
```$socket``` property and all ```private``` methods on the class were changed to ```protected```.

# Why it Was Changed
**TLDR:** We needed access to private stuff

We are using this library for a proprietary project, and we needed to extend functionality of the class, which required access to the socket object. Unfortunately this object was marked as private, so we had to fork the code instead. 
To avoid the necessity for ourselves and others in the future, we changed some visibility levels. 