### PR TITLE
(PHP 5.4+) Added "scanResource" method, and "scanLocalFile" now scans in a streaming manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ $result = $quahog->contScan('/tmp/virusdirectory');
 // Scan a file or directory recursively using multiple threads
 $result = $quahog->multiscanFile('/tmp/virusdirectory');
 
+// Scan a php streaming resource, such as a file, and optionally pass the maximum chunk size in bytes
+$result = $quahog->scanStream(fopen('/tmp/virusfile'), 1024);
+
 // Scan a stream, and optionally pass the maximum chunk size in bytes
 $result = $quahog->scanStream(file_get_contents('/tmp/virusfile'), 1024);
 


### PR DESCRIPTION
> If you would like any more information about my thinking, please let me know.

PHP 5.4+ version of PR #10

**TLDR:** Added ability to scan an arbitrary file or resource in a streaming manner, PHP 5.4+

**NOTE:** I apologize for having 2 PRs. But I realized that I originally wrote my changes in a 5.4+ friendly way, but Travis on this project checks PHP 5.3+. This is the 5.4+ version. Travis failing for PHP 5.3 is expected on this PR, but is not expected for 5.4+.
# What Was Changed
- **Added public method: scanResource** to scan a stream [resource](http://php.net/manual/en/language.types.resource.php) (e.g. returned from[ fopen()](http://php.net/manual/en/function.fopen.php))
- **Updated public method: scanLocalFile** to scan the specified file in a streaming manner
- **Added protected method: _chunkStream**, which allows you to apply a closure to chunks of a resource
- **Added protected method: _sendChunk** which sends a part of a file to ClamAV. Used to keep things a bit more clear and DRY
- **Updated unit tests and README.md**
# Decision Points
- **5.3 vs 5.4** - PHP 5.3 does not support using `$this` in closures, which breaks the use of _chunkStream (because it needs to access private / protected methods, ie access the socket).  I would prefer using the 5.4 PR, but that involves potentially breaking changes (ie requiring PHP5.4).
- **`scanStream` was not changed in order to avoid breaking any projects using this method.** Strictly speaking, this does not scan a stream, it scans a string in chunks. If the project owner would like to change the method signature, I can update my PR.
