### PR TITLE
Add support for nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
To be able to test against the newest PHP versions, I've added the nightly build to the travis.ci PHP matrix. Because it is tested with an instable version, failed test shouldn't break the whole build process of Quahog.