### PR TITLE
Introduce a value object for scan result

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ $quahog->shutdown();
 
 ```
 
+### Working with the result
+
+``` php
+// Result is an instance of \Xenolope\Quahog\Result.
+$result = $quahog->scanFile('/tmp/virusfile');
+
+// A result id of a session that was used.
+$result->getId();
+
+// The file name of the scanned file.
+$result->getFilename();
+
+// The reason why a scan resulted in a failure. Returns null if the scan was successful.
+$result->getReason();
+
+// A boolean value that is true, in case the scan was successful.
+$result->isOk();
+
+// A boolean value that is true, in case the scan failed. This is the opposite of isOk().
+$result->hasFailed();
+
+// A boolean value that is true, if a virus was found.
+$result->isFound();
+
+// A boolean value that is true, if an error happened.
+$result->isError();
+```
+
 ## Testing
 
 To run the test suite you will need PHPUnit installed. Go to the project root and run:

--- a/src/Quahog/Client.php
+++ b/src/Quahog/Client.php
@@ -123,7 +123,7 @@ class Client
      *
      * @param string $file The location of the file to scan.
      *
-     * @return array
+     * @return Result
      */
     public function scanFile($file)
     {
@@ -139,7 +139,7 @@ class Client
      *
      * @param string $file The location of the file or directory to scan.
      *
-     * @return array
+     * @return Result
      */
     public function multiscanFile($file)
     {
@@ -155,7 +155,7 @@ class Client
      *
      * @param string $file The location of the file or directory to scan.
      *
-     * @return array
+     * @return Result
      */
     public function contScan($file)
     {
@@ -172,7 +172,7 @@ class Client
      * @param string $file The location of the file to scan.
      * @param int    $maxChunkSize The maximum chunk size in bytes to send to clamd at a time.
      *
-     * @return array
+     * @return Result
      */
     public function scanLocalFile($file, $maxChunkSize = 1024)
     {
@@ -185,7 +185,7 @@ class Client
      * @param resource $stream A file stream
      * @param int      $maxChunkSize The maximum chunk size in bytes to send to clamd at a time.
      *
-     * @return array
+     * @return Result
      * @throws InvalidArgumentException
      */
     public function scanResourceStream($stream, $maxChunkSize = 1024)
@@ -215,7 +215,7 @@ class Client
      * @param string $stream A file stream in string form.
      * @param int    $maxChunkSize The maximum chunk size in bytes to send to clamd at a time.
      *
-     * @return array
+     * @return Result
      */
     public function scanStream($stream, $maxChunkSize = 1024)
     {
@@ -325,31 +325,30 @@ class Client
      *
      * @param string $response
      *
-     * @return array
+     * @return Result
      */
     private function _parseResponse($response)
     {
         $splitResponse = explode(': ', $response);
 
-        $idReturn = [];
+        $id = null;
         if (!$this->_inSession) {
             $filename = $splitResponse[0];
             $message = $splitResponse[1];
-        }
-        else {
-            $idReturn = ['id' => $splitResponse[0]];
+        } else {
+            $id = $splitResponse[0];
             $filename = $splitResponse[1];
             $message = $splitResponse[2];
         }
 
         if ($message === self::RESULT_OK) {
-            return $idReturn + ['filename' => $filename, 'reason' => null, 'status' => self::RESULT_OK];
-        } else {
-            $parts = explode(' ', $message);
-            $status = array_pop($parts);
-            $reason = implode(' ', $parts);
-
-            return $idReturn + ['filename' => $filename, 'reason' => $reason, 'status' => $status];
+            return new Result(self::RESULT_OK, $filename, null, $id);
         }
+
+        $parts = explode(' ', $message);
+        $status = array_pop($parts);
+        $reason = implode(' ', $parts);
+
+        return new Result($status, $filename, $reason, $id);
     }
 }

--- a/src/Quahog/Result.php
+++ b/src/Quahog/Result.php
@@ -30,6 +30,12 @@ class Result
      */
     private $status;
 
+    /**
+     * @param string      $status
+     * @param string      $filename
+     * @param null|string $reason
+     * @param null|string $id
+     */
     public function __construct(string $status, string $filename, ?string $reason, ?string $id)
     {
         $this->status   = $status;
@@ -39,7 +45,9 @@ class Result
     }
 
     /**
-     * @return string
+     * Returns a result id of a session was used.
+     *
+     * @return null|string
      */
     public function getId(): ?string
     {
@@ -47,6 +55,8 @@ class Result
     }
 
     /**
+     * Returns the filename of the scanned file.
+     *
      * @return string
      */
     public function getFilename(): string
@@ -55,6 +65,8 @@ class Result
     }
 
     /**
+     * Returns an explanation in case the scan found a virus or an error.
+     *
      * @return null|string
      */
     public function getReason(): ?string
@@ -63,33 +75,41 @@ class Result
     }
 
     /**
+     * Returns true if no errors and no virus are found.
+     *
      * @return bool
      */
-    public function ok(): bool
+    public function isOk(): bool
     {
         return $this->status === self::RESULT_OK;
     }
 
     /**
+     * Returns true if errors or a virus are found.
+     *
      * @return bool
      */
-    public function failed(): bool
+    public function hasFailed(): bool
     {
         return $this->status !== self::RESULT_OK;
     }
 
     /**
+     * Returns true if a virus was found.
+     *
      * @return bool
      */
-    public function found(): bool
+    public function isFound(): bool
     {
         return $this->status === self::RESULT_FOUND;
     }
 
     /**
+     * Returns true if an error was found.
+     *
      * @return bool
      */
-    public function error(): bool
+    public function isError(): bool
     {
         return $this->status === self::RESULT_ERROR;
     }

--- a/src/Quahog/Result.php
+++ b/src/Quahog/Result.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Xenolope\Quahog;
+
+class Result
+{
+    private const RESULT_OK    = 'OK';
+    private const RESULT_FOUND = 'FOUND';
+    private const RESULT_ERROR = 'ERROR';
+
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * @var string|null
+     */
+    private $reason;
+
+    /**
+     * @var string
+     */
+    private $status;
+
+    public function __construct(string $status, string $filename, ?string $reason, ?string $id)
+    {
+        $this->status   = $status;
+        $this->filename = $filename;
+        $this->reason   = $reason;
+        $this->id       = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @return bool
+     */
+    public function ok(): bool
+    {
+        return $this->status === self::RESULT_OK;
+    }
+
+    /**
+     * @return bool
+     */
+    public function failed(): bool
+    {
+        return $this->status !== self::RESULT_OK;
+    }
+
+    /**
+     * @return bool
+     */
+    public function found(): bool
+    {
+        return $this->status === self::RESULT_FOUND;
+    }
+
+    /**
+     * @return bool
+     */
+    public function error(): bool
+    {
+        return $this->status === self::RESULT_ERROR;
+    }
+}

--- a/tests/QuahogITTest.php
+++ b/tests/QuahogITTest.php
@@ -47,7 +47,7 @@ class QuahogITTest extends TestCase
 
         self::assertSame('stream', $result->getFilename());
         self::assertNull($result->getReason());
-        self::assertTrue($result->ok());
+        self::assertTrue($result->isOk());
     }
 
     /**
@@ -62,7 +62,7 @@ class QuahogITTest extends TestCase
 
         self::assertSame('stream', $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
     }
 
     /**
@@ -81,7 +81,7 @@ class QuahogITTest extends TestCase
 
             self::assertSame($name, $result->getFilename());
             self::assertNull($result->getReason());
-            self::assertTrue($result->ok());
+            self::assertTrue($result->isOk());
         } finally {
             unlink($name);
         }
@@ -102,7 +102,7 @@ class QuahogITTest extends TestCase
 
             self::assertSame($name, $result->getFilename());
             self::assertSame('Eicar-Test-Signature', $result->getReason());
-            self::assertTrue($result->found());
+            self::assertTrue($result->isFound());
         } finally {
             unlink($name);
         }
@@ -123,7 +123,7 @@ class QuahogITTest extends TestCase
 
             self::assertSame('stream', $result->getFilename());
             self::assertSame('Eicar-Test-Signature', $result->getReason());
-            self::assertTrue($result->found());
+            self::assertTrue($result->isFound());
         } finally {
             unlink($name);
         }
@@ -152,7 +152,7 @@ class QuahogITTest extends TestCase
 
             self::assertSame($file2, $result->getFilename());
             self::assertSame('Eicar-Test-Signature', $result->getReason());
-            self::assertTrue($result->found());
+            self::assertTrue($result->isFound());
         } finally {
             unlink($file1);
             unlink($file2);
@@ -183,7 +183,7 @@ class QuahogITTest extends TestCase
 
             self::assertSame($file2, $result->getFilename());
             self::assertSame('Eicar-Test-Signature', $result->getReason());
-            self::assertTrue($result->found());
+            self::assertTrue($result->isFound());
         } finally {
             unlink($file1);
             unlink($file2);
@@ -205,18 +205,18 @@ class QuahogITTest extends TestCase
         self::assertSame('stream', $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
         self::assertSame('1', $result->getId());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
 
         $result = $quahog->scanStream(self::EICAR);
         self::assertSame('stream', $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
         self::assertSame('2', $result->getId());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
 
         $result = $quahog->scanStream('ABC');
         self::assertSame('stream', $result->getFilename());
         self::assertSame('3', $result->getId());
-        self::assertTrue($result->ok());
+        self::assertTrue($result->isOk());
 
         $quahog->endSession();
         $quahog->disconnect();

--- a/tests/QuahogITTest.php
+++ b/tests/QuahogITTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Xenolope\Quahog\Tests;
 
 use PHPUnit\Framework\TestCase;
@@ -43,10 +44,10 @@ class QuahogITTest extends TestCase
         $quahog = new Client($socket, 30, PHP_NORMAL_READ);
 
         $result = $quahog->scanStream("ABC");
-        self::assertSame(
-            ['filename' => 'stream', 'reason' => null, 'status' => 'OK'],
-            $result
-        );
+
+        self::assertSame('stream', $result->getFilename());
+        self::assertNull($result->getReason());
+        self::assertTrue($result->ok());
     }
 
     /**
@@ -58,10 +59,10 @@ class QuahogITTest extends TestCase
         $quahog = new Client($socket, 30, PHP_NORMAL_READ);
 
         $result = $quahog->scanStream(self::EICAR);
-        self::assertSame(
-            ['filename' => 'stream', 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-            $result
-        );
+
+        self::assertSame('stream', $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertTrue($result->found());
     }
 
     /**
@@ -77,10 +78,10 @@ class QuahogITTest extends TestCase
 
         try {
             $result = $quahog->scanFile($name);
-            self::assertSame(
-                ['filename' => $name, 'reason' => null, 'status' => 'OK'],
-                $result
-            );
+
+            self::assertSame($name, $result->getFilename());
+            self::assertNull($result->getReason());
+            self::assertTrue($result->ok());
         } finally {
             unlink($name);
         }
@@ -98,10 +99,10 @@ class QuahogITTest extends TestCase
 
         try {
             $result = $quahog->scanFile($name);
-            self::assertSame(
-                ['filename' => $name, 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-                $result
-            );
+
+            self::assertSame($name, $result->getFilename());
+            self::assertSame('Eicar-Test-Signature', $result->getReason());
+            self::assertTrue($result->found());
         } finally {
             unlink($name);
         }
@@ -119,10 +120,10 @@ class QuahogITTest extends TestCase
 
         try {
             $result = $quahog->scanResourceStream(fopen($name, "r"));
-            self::assertSame(
-                ['filename' => 'stream', 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-                $result
-            );
+
+            self::assertSame('stream', $result->getFilename());
+            self::assertSame('Eicar-Test-Signature', $result->getReason());
+            self::assertTrue($result->found());
         } finally {
             unlink($name);
         }
@@ -148,10 +149,10 @@ class QuahogITTest extends TestCase
         chmod($file2, 0777);
         try {
             $result = $quahog->multiscanFile($name);
-            self::assertSame(
-                ['filename' => $file2, 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-                $result
-            );
+
+            self::assertSame($file2, $result->getFilename());
+            self::assertSame('Eicar-Test-Signature', $result->getReason());
+            self::assertTrue($result->found());
         } finally {
             unlink($file1);
             unlink($file2);
@@ -179,10 +180,10 @@ class QuahogITTest extends TestCase
         chmod($file2, 0777);
         try {
             $result = $quahog->contScan($name);
-            self::assertSame(
-                ['filename' => $file2, 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-                $result
-            );
+
+            self::assertSame($file2, $result->getFilename());
+            self::assertSame('Eicar-Test-Signature', $result->getReason());
+            self::assertTrue($result->found());
         } finally {
             unlink($file1);
             unlink($file2);
@@ -200,20 +201,23 @@ class QuahogITTest extends TestCase
 
         $quahog->startSession();
         $result = $quahog->scanStream(self::EICAR);
-        self::assertSame(
-            ['id' => '1', 'filename' => "stream", 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-            $result
-        );
+
+        self::assertSame('stream', $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertSame('1', $result->getId());
+        self::assertTrue($result->found());
+
         $result = $quahog->scanStream(self::EICAR);
-        self::assertSame(
-            ['id' => '2', 'filename' => "stream", 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-            $result
-        );
+        self::assertSame('stream', $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertSame('2', $result->getId());
+        self::assertTrue($result->found());
+
         $result = $quahog->scanStream('ABC');
-        self::assertSame(
-            ['id' => '3', 'filename' => "stream", 'reason' => null, 'status' => 'OK'],
-            $result
-        );
+        self::assertSame('stream', $result->getFilename());
+        self::assertSame('3', $result->getId());
+        self::assertTrue($result->ok());
+
         $quahog->endSession();
         $quahog->disconnect();
     }

--- a/tests/QuahogTest.php
+++ b/tests/QuahogTest.php
@@ -94,7 +94,7 @@ class QuahogTest extends TestCase
 
         self::assertSame('/tmp/EICAR', $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
     }
 
     public function testMultiscanFile()
@@ -105,7 +105,7 @@ class QuahogTest extends TestCase
         $result = $this->quahog->multiscanFile('/tmp/quahog');
 
         self::assertSame('Eicar-Test-Signature', $result->getReason());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
     }
 
     public function testContScan()
@@ -117,7 +117,7 @@ class QuahogTest extends TestCase
 
         self::assertSame('/tmp/quahog/EICAR', $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
     }
 
     public function testScanLocalFile()
@@ -133,7 +133,7 @@ class QuahogTest extends TestCase
 
         self::assertSame($file->url(), $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
     }
 
     public function testScanStream()
@@ -145,7 +145,7 @@ class QuahogTest extends TestCase
 
         self::assertSame('stream', $result->getFilename());
         self::assertSame('Eicar-Test-Signature', $result->getReason());
-        self::assertTrue($result->found());
+        self::assertTrue($result->isFound());
     }
 
     public function testShutdown()

--- a/tests/QuahogTest.php
+++ b/tests/QuahogTest.php
@@ -92,10 +92,9 @@ class QuahogTest extends TestCase
 
         $result = $this->quahog->scanFile('/tmp/EICAR');
 
-        self::assertSame(
-            array('filename' => '/tmp/EICAR', 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'),
-            $result
-        );
+        self::assertSame('/tmp/EICAR', $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertTrue($result->found());
     }
 
     public function testMultiscanFile()
@@ -105,8 +104,8 @@ class QuahogTest extends TestCase
 
         $result = $this->quahog->multiscanFile('/tmp/quahog');
 
-        self::assertSame('Eicar-Test-Signature', $result['reason']);
-        self::assertSame('FOUND', $result['status']);
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertTrue($result->found());
     }
 
     public function testContScan()
@@ -116,10 +115,9 @@ class QuahogTest extends TestCase
 
         $result = $this->quahog->contScan('/tmp/quahog');
 
-        self::assertSame(
-            ['filename' => '/tmp/quahog/EICAR', 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-            $result
-        );
+        self::assertSame('/tmp/quahog/EICAR', $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertTrue($result->found());
     }
 
     public function testScanLocalFile()
@@ -133,10 +131,9 @@ class QuahogTest extends TestCase
 
         $result = $this->quahog->scanLocalFile($file->url());
 
-        self::assertSame(
-            ['filename' => $file->url(), 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-            $result
-        );
+        self::assertSame($file->url(), $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertTrue($result->found());
     }
 
     public function testScanStream()
@@ -146,10 +143,9 @@ class QuahogTest extends TestCase
 
         $result = $this->quahog->scanStream('stream');
 
-        self::assertSame(
-            ['filename' => 'stream', 'reason' => 'Eicar-Test-Signature', 'status' => 'FOUND'],
-            $result
-        );
+        self::assertSame('stream', $result->getFilename());
+        self::assertSame('Eicar-Test-Signature', $result->getReason());
+        self::assertTrue($result->found());
     }
 
     public function testShutdown()

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Xenolope\Quahog\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Xenolope\Quahog\Result;
+
+class ResultTest extends TestCase
+{
+    public function testCleanResult(): void
+    {
+        $result = new Result('OK', 'filename', null, null);
+
+        self::assertSame('filename', $result->getFilename());
+        self::assertTrue($result->ok());
+        self::assertNull($result->getId());
+        self::assertNull($result->getReason());
+        self::assertFalse($result->error());
+        self::assertFalse($result->found());
+    }
+
+    public function testVirusFound(): void
+    {
+        $result = new Result('FOUND', 'filename', 'evilvirus', '1');
+
+        self::assertSame('filename', $result->getFilename());
+        self::assertSame('evilvirus', $result->getReason());
+        self::assertSame('1', $result->getId());
+        self::assertFalse($result->ok());
+        self::assertTrue($result->failed());
+        self::assertFalse($result->error());
+        self::assertTrue($result->found());
+    }
+
+    public function testError(): void
+    {
+        $result = new Result('ERROR', 'filename', 'broken', '1');
+
+        self::assertSame('filename', $result->getFilename());
+        self::assertSame('broken', $result->getReason());
+        self::assertSame('1', $result->getId());
+        self::assertFalse($result->ok());
+        self::assertTrue($result->failed());
+        self::assertTrue($result->error());
+        self::assertFalse($result->found());
+    }
+
+    public function testUndefinedFailure(): void
+    {
+        $result = new Result('WHAT', 'filename', 'text', '1');
+
+        self::assertSame('filename', $result->getFilename());
+        self::assertSame('text', $result->getReason());
+        self::assertSame('1', $result->getId());
+        self::assertFalse($result->ok());
+        self::assertTrue($result->failed());
+        self::assertFalse($result->error());
+        self::assertFalse($result->found());
+    }
+}

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -14,11 +14,11 @@ class ResultTest extends TestCase
         $result = new Result('OK', 'filename', null, null);
 
         self::assertSame('filename', $result->getFilename());
-        self::assertTrue($result->ok());
+        self::assertTrue($result->isOk());
         self::assertNull($result->getId());
         self::assertNull($result->getReason());
-        self::assertFalse($result->error());
-        self::assertFalse($result->found());
+        self::assertFalse($result->isError());
+        self::assertFalse($result->isFound());
     }
 
     public function testVirusFound(): void
@@ -28,10 +28,10 @@ class ResultTest extends TestCase
         self::assertSame('filename', $result->getFilename());
         self::assertSame('evilvirus', $result->getReason());
         self::assertSame('1', $result->getId());
-        self::assertFalse($result->ok());
-        self::assertTrue($result->failed());
-        self::assertFalse($result->error());
-        self::assertTrue($result->found());
+        self::assertFalse($result->isOk());
+        self::assertTrue($result->hasFailed());
+        self::assertFalse($result->isError());
+        self::assertTrue($result->isFound());
     }
 
     public function testError(): void
@@ -41,10 +41,10 @@ class ResultTest extends TestCase
         self::assertSame('filename', $result->getFilename());
         self::assertSame('broken', $result->getReason());
         self::assertSame('1', $result->getId());
-        self::assertFalse($result->ok());
-        self::assertTrue($result->failed());
-        self::assertTrue($result->error());
-        self::assertFalse($result->found());
+        self::assertFalse($result->isOk());
+        self::assertTrue($result->hasFailed());
+        self::assertTrue($result->isError());
+        self::assertFalse($result->isFound());
     }
 
     public function testUndefinedFailure(): void
@@ -54,9 +54,9 @@ class ResultTest extends TestCase
         self::assertSame('filename', $result->getFilename());
         self::assertSame('text', $result->getReason());
         self::assertSame('1', $result->getId());
-        self::assertFalse($result->ok());
-        self::assertTrue($result->failed());
-        self::assertFalse($result->error());
-        self::assertFalse($result->found());
+        self::assertFalse($result->isOk());
+        self::assertTrue($result->hasFailed());
+        self::assertFalse($result->isError());
+        self::assertFalse($result->isFound());
     }
 }


### PR DESCRIPTION
Arrays have no API and are structureless, which is why I introduce for a next major release a `Result` object, that is returned instead of an array after a scan.

This object introduces the following methods:

- `getId` - Returns the id of the scan result. If none exists, it returns null
- `getFilename` - Returns the file name
- `getReason` - Returns the reason of a failure. If scan wasn't failing, it returns null
- `ok` - Boolean value that is true, if the scan found nothing or no error occurred
- `failed` - Boolean value that is true, if the scan found something or an error happened
- `found` - Boolean value that is true, when a virus was found
- `error` - Boolean value that is true, when an error was found

This is a first draft for the return value of a scan. I'm not sure if we need a `failure` method, because it is the opposite of `ok`, but I added it for a readability purpose.